### PR TITLE
Fix idempotency

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,7 @@
   command: timedatectl
   register: timedatectl
   ignore_errors: yes
+  changed_when: false
 
 - include: timedatectl.yml
   when: timedatectl.rc is defined and timedatectl.rc == 0


### PR DESCRIPTION
The "Get timedatectl information" task uses command module which always return changed -> true (at least without creates / removes parameters).
This will always force changed -> false on that task so you can check playbook idempotency with tools like molecule.